### PR TITLE
Removed stray 100% from vertical-three-colours mixin

### DIFF
--- a/vendor/assets/stylesheets/bootstrap/_mixins.scss
+++ b/vendor/assets/stylesheets/bootstrap/_mixins.scss
@@ -425,7 +425,7 @@
   background-color: mix($midColor, $endColor, 80%);
   background-image: -webkit-gradient(linear, 0 0, 0 100%, from($startColor), color-stop($colorStop, $midColor), to($endColor));
   background-image: -webkit-linear-gradient($startColor, $midColor $colorStop, $endColor);
-  background-image: -moz-linear-gradient(top, $startColor, $midColor $colorStop*100%, $endColor);
+  background-image: -moz-linear-gradient(top, $startColor, $midColor $colorStop, $endColor);
   background-image: -o-linear-gradient($startColor, $midColor $colorStop, $endColor);
   background-image: linear-gradient($startColor, $midColor $colorStop, $endColor);
   background-repeat: no-repeat;


### PR DESCRIPTION
In the gradient-vertical-three-colours mixin, the mozilla specific call multiplied the colour stop by 100%.  This was not present in the original bootstrap mixin(1) and was not present in bootstrap-sass 2.0.4.0.  The mozilla documentation also does not indicate any difference in syntax is necessary (2)

Before my edit, we were getting errors such as:

> 7000%*% isn't a valid CSS value.

when using the mixin.  With my edit the mixin functions correctly.  Would it be possible to accept this patch and update the Gem?

Thanks heaps,
Jason O'Neil

(1) https://github.com/twitter/bootstrap/blob/master/less/mixins.less
(2) https://developer.mozilla.org/en-US/docs/CSS/linear-gradient?redirectlocale=en-US&redirectslug=CSS%2F-moz-linear-gradient#Cross-browser_gradients
